### PR TITLE
feat: add arrow kotlin dependencies to gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.targets.js.KotlinJsCompilerAttribute
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
+val arrowVersion = "1.1.2"
 val kotlinVersion: String by System.getProperties()
 val kotlinIdeVersion: String by System.getProperties()
 val policy: String by System.getProperties()
@@ -86,6 +87,11 @@ dependencies {
     kotlinDependency("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
     kotlinDependency("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4")
     kotlinJsDependency("org.jetbrains.kotlin:kotlin-stdlib-js:$kotlinVersion")
+
+    kotlinDependency("io.arrow-kt:arrow-core:$arrowVersion")
+    kotlinDependency("io.arrow-kt:arrow-fx-coroutines:$arrowVersion")
+    kotlinDependency("io.arrow-kt:arrow-fx-stm:$arrowVersion")
+    kotlinDependency("io.arrow-kt:arrow-optics:$arrowVersion")
 
     annotationProcessor("org.springframework:spring-context-indexer")
     implementation("org.springframework.boot:spring-boot-starter-web")


### PR DESCRIPTION
# Changes included
- Added Arrow dependencies to build.gradle.kt

# How to use this server inside kotlin-playground

1. Add kotlin-playground as NPM dependency of your web app: `npm install kotlin-playground -S`

2. Configure and use kotlin-playground:

```js
// ES6
import playground from 'kotlin-playground';

const options = {
   server: 'http://localhost:8080' // an instance of kotlin-compiler-server
};

playground('.kotlin-code', options); // attach to all class="kotlin-code" elements
```

3. Create some HTML element hosting Kotlin with Arrow code:
```kotlin
<div class="kotlin-code">
   import arrow.core.Either

   val right: Either<String, Int> =
   //sampleStart
   Either.Right(5)
   //sampleEnd
   fun main() {
      println(right)
   }
</div>
```


For more information check the [project's GitHub](https://github.com/JetBrains/kotlin-playground).