### PR TITLE
feat: add arrow kotlin dependencies to gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.targets.js.KotlinJsCompilerAttribute
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
+val arrowVersion = "1.1.2"
 val kotlinVersion: String by System.getProperties()
 val kotlinIdeVersion: String by System.getProperties()
 val policy: String by System.getProperties()
@@ -86,6 +87,11 @@ dependencies {
     kotlinDependency("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
     kotlinDependency("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4")
     kotlinJsDependency("org.jetbrains.kotlin:kotlin-stdlib-js:$kotlinVersion")
+
+    kotlinDependency("io.arrow-kt:arrow-core:$arrowVersion")
+    kotlinDependency("io.arrow-kt:arrow-fx-coroutines:$arrowVersion")
+    kotlinDependency("io.arrow-kt:arrow-fx-stm:$arrowVersion")
+    kotlinDependency("io.arrow-kt:arrow-optics:$arrowVersion")
 
     annotationProcessor("org.springframework:spring-context-indexer")
     implementation("org.springframework.boot:spring-boot-starter-web")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.targets.js.KotlinJsCompilerAttribute
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
-val arrowVersion = "1.1.2"
+val arrowVersion = "1.1.5"
 val kotlinVersion: String by System.getProperties()
 val kotlinIdeVersion: String by System.getProperties()
 val policy: String by System.getProperties()


### PR DESCRIPTION
# Changes included
- Added Arrow dependencies to build.gradle.kts.

# How to use 

In order to use `kotlin-compiler-server` with `kotlin-playground` inside a web app, follow these steps:

1. Build and run `kotlin-compiler-server` (see [README.md](https://github.com/47deg/kotlin-compiler-server/blob/arrow/README.md))

2. Inside your web app, add `kotlin-playground` as NPM dependency `npm install kotlin-playground -S`

3. Configure and use `kotlin-playground` inside the web app:

```js
// ES6
import playground from 'kotlin-playground';

const options = {
   server: 'http://localhost:8080' // an instance of kotlin-compiler-server 
};

playground('.kotlin-code', options); // attach to all class="kotlin-code" elements
```

4. Create some HTML element hosting Kotlin with Arrow code:
```kotlin
<div class="kotlin-code">
   import arrow.core.Either

   val right: Either<String, Int> =
   //sampleStart
   Either.Right(5)
   //sampleEnd
   fun main() {
      println(right)
   }
</div>
```
5. Run the web app.

NOTE: for more information about `kotlin-playground`, check the [project's GitHub](https://github.com/JetBrains/kotlin-playground).

